### PR TITLE
Fix assignment of marker sensor value to variable

### DIFF
--- a/STM32CubeIDE_file/main.c
+++ b/STM32CubeIDE_file/main.c
@@ -283,11 +283,11 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim){
 //PA5 ADC2_IN2  LL1
 //PA6 ADC2_IN3  LL2
 //PA7 ADC2_IN4  POWER
-//PB0 ADC1_IN11 マーカーL
-//PB1 ADC1_IN12 マーカーR
+//PB0 ADC1_IN11 マーカーR
+//PB1 ADC1_IN12 マーカーL
 		R2_Value = ADC1_DATA[0];
-		ML_Value = ADC1_DATA[1];
-		MR_Value = ADC1_DATA[2];
+		MR_Value = ADC1_DATA[1];
+		ML_Value = ADC1_DATA[2];
 		R1_Value = ADC2_DATA[0];
 		L1_Value = ADC2_DATA[1];
 		L2_Value = ADC2_DATA[2];


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
STM32CubeIDE_fileのmain.c内の左右のマーカーセンサのAD変換値の代入が逆になっていたので修正した。
![DSC_0097](https://user-images.githubusercontent.com/47343458/91812847-b9707700-ec6c-11ea-83c5-2c7135fc171e.JPG)
右がPB0、左がPB1に繋がっている。
ADC1_DATA[1]がPB0、ADC1_DATA[2]がPB1のデータを保存している。





- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
